### PR TITLE
Persist full cert with details

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -48,6 +48,7 @@ impl Consumer {
                             info.cert = base64::encode(&bytes[start..end]);
                             let bytes = serde_json::to_vec(&info)?;
                             writer.write_all(&bytes).await?;
+                            writer.write_all(b"\n").await?;
                         }
                         Err(err) => println!("Error at position {}: {}", position, err),
                     }


### PR DESCRIPTION
This will allow us to easier parse certs later if we want more details.