### PR TITLE
Add timeout to requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +354,7 @@ dependencies = [
  "base64",
  "der-parser",
  "encoding",
+ "env_logger",
  "futures 0.3.5",
  "http",
  "reqwest",
@@ -462,6 +474,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -807,10 +832,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
-name = "hyper"
-version = "0.13.6"
+name = "humantime"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "hyper"
+version = "0.13.4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -822,8 +854,8 @@ dependencies = [
  "httparse",
  "itoa",
  "log",
+ "net2",
  "pin-project",
- "socket2",
  "time",
  "tokio",
  "tower-service",
@@ -832,9 +864,7 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "hyper",
@@ -1258,6 +1288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,8 +1379,6 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
  "base64",
  "bytes",
@@ -1609,6 +1643,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1906,6 +1949,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use reqwest::{Client, Request, Response};
 use serde::{Deserialize, Serialize};
-use std::error::Error;
+use std::{error::Error, time::Duration};
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Logs {
@@ -109,6 +109,7 @@ impl<'a> CtClient for HttpCtClient<'a> {
                         "{}/get-entries?start={}&end={}",
                         self.base_url, start, end
                     ))
+                    .timeout(Duration::from_secs(20))
                     .build()?,
             )
             .await?;
@@ -124,6 +125,7 @@ impl<'a> CtClient for HttpCtClient<'a> {
             .request(
                 self.client
                     .get(&format!("{}/get-sth", self.base_url))
+                    .timeout(Duration::from_secs(20))
                     .build()?,
             )
             .await?;


### PR DESCRIPTION
Ive noticed that when running ctlogs for a long time, say a few hours, if the network cuts out as it is reading from the response body it will hang indefinitely. This occurs in hyper at
https://github.com/hyperium/hyper/blob/4b6099c7aa558e6b1fda146ce6179cb0c67858d7/src/body/to_bytes.rs#L10-L40.